### PR TITLE
[2/2] vendor: introduce TARGET_LOW_RAM_DEVICE

### DIFF
--- a/config/packages.mk
+++ b/config/packages.mk
@@ -1,7 +1,9 @@
 # Additional packages
+ifneq ($(TARGET_LOW_RAM_DEVICE), true)
 PRODUCT_PACKAGES += \
     Basic \
     Development
+endif
 
 # Additional apps
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
make a minimal build for low memory devices

flag: TARGET_LOW_RAM_DEVICE

In general this entry is located on device repo, in omni_[device name].mk
It should be declared before full_base_telephony.mk inherit statement

[1]: https://gerrit.omnirom.org/#/c/12538/

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I74f543d8ba567840da636de7916db69c412e06cd